### PR TITLE
Fix/promise try

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
  */
 
 const Client = require('mongodb').MongoClient;
-Promise = require('bluebird');
+const Promise = require('bluebird');
 const zlib = require('zlib');
 const _ = require('lodash');
 const validOptionNames = ['poolSize', 'ssl', 'sslValidate', 'sslCA', 'sslCert',

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
  */
 
 const Client = require('mongodb').MongoClient;
+Promise = require('bluebird');
 const zlib = require('zlib');
 const _ = require('lodash');
 const validOptionNames = ['poolSize', 'ssl', 'sslValidate', 'sslCA', 'sslCert',
@@ -46,25 +47,20 @@ class MongoStore {
 
   getCollection() {
     var store = this;
-
-    return new Promise((resolve, reject) => {
-      try {
-        if (store.client && store.collection)
-          return resolve(store.collection);
-        return resolve(store.initClient());
-      } catch(error) {
-        reject(error);
-      }
+    return Promise.try(() => {
+      if (store.client && store.collection)
+        return store.collection;
+      return store.initClient();
     });
 
   }
 
   initClient() {
     var store = this;
-    let uri = store.uri;
-
-    return Client.connect(uri, _.pick(store.MongoOptions, validOptionNames)
-    ).then((client) => {
+    return Promise.try(() => {
+      let uri = store.uri;
+      return Client.connect(uri, _.pick(store.MongoOptions, validOptionNames));
+    }).then((client) => {
       return client.db();
     }).then((db) => {
       store.client = db;

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,11 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "author": "V4l3r10",
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.5.3",
     "cache-manager": "^2.9.0",
     "lodash": "^4.17.15",
     "mongodb": "^3.1.13"


### PR DESCRIPTION
I tried the fork, and it didn't work because `Promise.prototype.constructor` is not a equivalence of `Promise.try`
The final diff to the original is just https://github.com/v4l3r10/node-cache-manager-mongodb/compare/master...openrm:fix/promise-try